### PR TITLE
Fix mis-detection of access code when address digits precede label

### DIFF
--- a/rp_extractor.py
+++ b/rp_extractor.py
@@ -403,7 +403,11 @@ def sniff_track_code_with_labels(text: str):
             if CODE_LABEL_RE.search(line_text) or CODE_LABEL_RE.search(prev_line):
                 score = 5
             elif CODE_LABEL_RE.search(next_line):
-                score = max(score, 5)
+                clean_line = re.sub(r"[\s\u00a0-]", "", line_text)
+                if clean_line.isdigit() and clean_line == digits:
+                    score = max(score, 5)
+                else:
+                    score = max(score, 3)
             elif line_has_code_kw:
                 score = 4
             elif CODE_CONTEXT_RE.search(prev_line) or CODE_CONTEXT_RE.search(next_line):

--- a/tests/test_sniff.py
+++ b/tests/test_sniff.py
@@ -103,4 +103,17 @@ def test_sniff_detects_code_with_label_on_previous_line():
     track, code = sniff_track_code_with_labels(text)
     assert track == "80001234567890"
     assert code == "11223344"
+
+
+def test_sniff_prefers_labelled_code_over_address_digits():
+    text = (
+        "ШПИ 8010 4511 6495 46\n"
+        "Куда: 199034, г. Санкт-Петербург, наб. Лейтенанта Шмидта,\n"
+        "д. 5/16, литера А, пом. 2-н, ком. 65\n"
+        "199034 Получайте и отправляйте письма онлайн.\n"
+        "Код доступа: 8126 4026\n"
+    )
+    track, code = sniff_track_code_with_labels(text)
+    assert track == "80104511649546"
+    assert code == "81264026"
     


### PR DESCRIPTION
## Summary
- prevent address lines from receiving the same confidence boost as real codes when the code label is on the next line
- add a regression test that covers the address + instruction layout from the failing attachments

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c95d519ab48325b39bda91684bd393