### PR TITLE
Fix dark theme spinbox colors

### DIFF
--- a/rp_extractor_gui_tk.py
+++ b/rp_extractor_gui_tk.py
@@ -80,6 +80,7 @@ class App(tk.Tk):
         style.theme_use("clam")
         style.configure(".", background=bg, foreground=fg)
         style.configure("TEntry", fieldbackground="#3c3f41", foreground=fg)
+        style.configure("TSpinbox", fieldbackground="#3c3f41", foreground=fg)
         style.configure("TCheckbutton", background=bg, foreground=fg)
         style.configure("TButton", background="#444", foreground=fg)
         style.configure("TProgressbar", background=accent)


### PR DESCRIPTION
## Summary
- ensure ttk spinboxes use the same dark background and foreground colors as other inputs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca9bf4f57483259db87daba36ba45e