### PR TITLE
Fix portable Tesseract path

### DIFF
--- a/portable/run_cli.bat
+++ b/portable/run_cli.bat
@@ -1,7 +1,7 @@
 @echo off
 setlocal
 set "BASEDIR=%~dp0"
-set "TESSERACT_PATH=%BASEDIR%tesseract\Tesseract-OCR\tesseract.exe"
+set "TESSERACT_PATH=%BASEDIR%Tesseract-OCR\tesseract.exe"
 set "POPPLER_PATH=%BASEDIR%poppler\bin"
 "%BASEDIR%rp_extractor.exe" ^
   --input "%USERPROFILE%\Documents\PDFs" ^

--- a/portable/run_gui.bat
+++ b/portable/run_gui.bat
@@ -1,6 +1,6 @@
 @echo off
 setlocal
 set "BASEDIR=%~dp0"
-set "TESSERACT_PATH=%BASEDIR%tesseract\Tesseract-OCR\tesseract.exe"
+set "TESSERACT_PATH=%BASEDIR%Tesseract-OCR\tesseract.exe"
 set "POPPLER_PATH=%BASEDIR%poppler\bin"
 start "" "%BASEDIR%rp_extractor_gui.exe"

--- a/run_cli.bat
+++ b/run_cli.bat
@@ -1,7 +1,7 @@
 @echo off
 setlocal
 set "BASEDIR=%~dp0"
-set "TESSERACT_PATH=%BASEDIR%tesseract\Tesseract-OCR\tesseract.exe"
+set "TESSERACT_PATH=%BASEDIR%Tesseract-OCR\tesseract.exe"
 set "POPPLER_PATH=%BASEDIR%poppler\bin"
 "%BASEDIR%rp_extractor.exe" ^
   --input "%USERPROFILE%\Desktop\PDFs" ^

--- a/run_gui.bat
+++ b/run_gui.bat
@@ -1,6 +1,6 @@
 @echo off
 setlocal
 set "BASEDIR=%~dp0"
-set "TESSERACT_PATH=%BASEDIR%tesseract\Tesseract-OCR\tesseract.exe"
+set "TESSERACT_PATH=%BASEDIR%Tesseract-OCR\tesseract.exe"
 set "POPPLER_PATH=%BASEDIR%poppler\bin"
 start "" "%BASEDIR%rp_extractor_gui.exe"


### PR DESCRIPTION
## Summary
- point Windows launcher scripts at the new Tesseract-OCR folder location for portable builds

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca9fc9f1408325a45536681b7466f9